### PR TITLE
Fix: Add ChromaDB dependency for admin endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,9 @@ python-multipart>=0.0.6
 pandas>=2.1.0
 numpy>=1.24.0
 
+# Vector database for embeddings
+chromadb>=0.4.15
+
 # MCP SDKs (if available as packages)
 # ref-tools
 # exa-py


### PR DESCRIPTION
## Summary
Fixes import error for admin endpoints by adding missing ChromaDB dependency.

## Issue
Admin endpoints were returning "Not Found" because the `chromadb` import in `admin_endpoints.py` was failing, causing `ADMIN_ENDPOINTS_AVAILABLE = False`.

## Fix
- Added `chromadb>=0.4.15` to `requirements.txt`
- Enables successful import of admin endpoints module
- Required for database migration functionality

## Test plan
After deployment:
- [ ] `curl https://healthassistant-production-3613.up.railway.app/admin/database-status` should return valid JSON
- [ ] Admin endpoints available for database migration

🤖 Generated with [Claude Code](https://claude.ai/code)